### PR TITLE
18 method missing mechanism

### DIFF
--- a/src/main/groovy/com/passfailerror/Jenkinson.groovy
+++ b/src/main/groovy/com/passfailerror/Jenkinson.groovy
@@ -57,7 +57,6 @@ class Jenkinson {
         this.steps = new Steps(resultStackProcessor)
         this.sections = new Sections(resultStackProcessor)
         mockJenkinsDefaults(pipelineScript)
-        mockSectionDefaults(pipelineScript)
     }
 
     def run() {
@@ -92,10 +91,6 @@ class Jenkinson {
             }
             resultStackProcessor.storeInvocation(currentStepName, params, pipelineScript.getBinding().getVariables())
         }
-    }
-
-    def mockSectionDefaults(pipelineScript) {
-        sections.mockDefaults(pipelineScript)
     }
 
     ActionableTokenDsl emulateStep(item) {

--- a/src/main/groovy/com/passfailerror/Jenkinson.groovy
+++ b/src/main/groovy/com/passfailerror/Jenkinson.groovy
@@ -58,6 +58,7 @@ class Jenkinson {
         this.steps = new Steps(resultStackProcessor)
         this.sections = new Sections(resultStackProcessor)
         mockJenkinsDefaults(pipelineScript)
+        mockSectionDefaults(pipelineScript)
     }
 
     def run() {
@@ -80,6 +81,9 @@ class Jenkinson {
 
     def mockJenkinsDefaults(pipelineScript) {
         steps.mockDefaults(pipelineScript)
+    }
+
+    def mockSectionDefaults(pipelineScript) {
         sections.mockDefaults(pipelineScript)
     }
 

--- a/src/main/groovy/com/passfailerror/Jenkinson.groovy
+++ b/src/main/groovy/com/passfailerror/Jenkinson.groovy
@@ -80,7 +80,10 @@ class Jenkinson {
     }
 
     def mockJenkinsDefaults(pipelineScript) {
-        steps.mockDefaults(pipelineScript)
+        pipelineScript.metaClass.methodMissing = { String currentStepName, params ->
+            log.info(currentStepName + " " + params[0].toString())
+            resultStackProcessor.storeInvocation(currentStepName, params, pipelineScript.getBinding().getVariables())
+        }
     }
 
     def mockSectionDefaults(pipelineScript) {

--- a/src/main/groovy/com/passfailerror/Jenkinson.groovy
+++ b/src/main/groovy/com/passfailerror/Jenkinson.groovy
@@ -1,6 +1,5 @@
 package com.passfailerror
 
-
 import com.passfailerror.assertion.DeclarativeAssertion
 import com.passfailerror.assertion.GeneralAssertion
 import com.passfailerror.syntax.actionable.EmulatingToken
@@ -81,7 +80,16 @@ class Jenkinson {
 
     def mockJenkinsDefaults(pipelineScript) {
         pipelineScript.metaClass.methodMissing = { String currentStepName, params ->
-            log.info(currentStepName + " " + params[0].toString())
+            if (params.find({ it instanceof Closure}) != null) {
+                log.info(currentStepName)
+                if (params.length > 1) {
+                    params[1].call() // stage("name"){closure}
+                } else {
+                    params[0].call() // steps{closure}
+                }
+            } else {
+                log.info(currentStepName + " " + params[0].toString())
+            }
             resultStackProcessor.storeInvocation(currentStepName, params, pipelineScript.getBinding().getVariables())
         }
     }

--- a/src/main/groovy/com/passfailerror/syntax/Sections.groovy
+++ b/src/main/groovy/com/passfailerror/syntax/Sections.groovy
@@ -8,24 +8,6 @@ import groovy.util.logging.Slf4j
 class Sections implements Token {
 
     final ResultStackProcessor resultStackProcessor
-    def defaultSections = ["pipeline",
-                           "agent",
-                           "stages",
-                           "stage",
-                           "steps",
-                           "parameters",
-                           "options",
-                           "node",
-                           "environment",
-                           "post",
-                           "always",
-                           "script",
-                           "when",
-                           "not",
-                           "triggers",
-                           "catchError",
-                           "dir",
-                           "withCredentials"]
 
     @NullCheck
     Sections(resultStackProcessor) {
@@ -36,19 +18,5 @@ class Sections implements Token {
     }
 
     def mockDefaults(pipelineScript) {
-        defaultSections.each {
-            section ->
-                def currentSection = section
-                pipelineScript.metaClass."$currentSection" = { Object... params ->
-                    log.info(currentSection)
-                    if (params.length > 1) {
-                        params[1].call() // stage("name"){closure}
-                    } else {
-                        params[0].call() // steps{closure}
-                    }
-                    resultStackProcessor.storeInvocation(currentSection, params, pipelineScript.getBinding().getVariables())
-                }
-
-        }
     }
 }

--- a/src/main/groovy/com/passfailerror/syntax/Sections.groovy
+++ b/src/main/groovy/com/passfailerror/syntax/Sections.groovy
@@ -16,7 +16,4 @@ class Sections implements Token {
 
     def mock(pipelineScript) {
     }
-
-    def mockDefaults(pipelineScript) {
-    }
 }

--- a/src/main/groovy/com/passfailerror/syntax/Steps.groovy
+++ b/src/main/groovy/com/passfailerror/syntax/Steps.groovy
@@ -14,29 +14,6 @@ class Steps implements Token {
         this.resultStackProcessor = resultStackProcessor
     }
 
-    def defaultSteps = ["label",
-                        "echo",
-                        "sh",
-                        "logRotator",
-                        "buildDiscarder",
-                        "skipDefaultChackout",
-                        "timestamps",
-                        "timeout",
-                        "disableConcurrentBuilds",
-                        "office365ConnectorWebhooks",
-                        "cleanWs",
-                        "library",
-                        "tool",
-                        "modernSCM",
-                        "checkout",
-                        "build",
-                        "usernamePassword",
-                        "office365ConnectorSend",
-                        "archiveArtifacts",
-                        "beforeAgent",
-                        "environment",
-                        "cron"]
-
     def actionableList = []
 
     def mockDefaults(pipelineScript) {

--- a/src/main/groovy/com/passfailerror/syntax/Steps.groovy
+++ b/src/main/groovy/com/passfailerror/syntax/Steps.groovy
@@ -16,9 +16,6 @@ class Steps implements Token {
 
     def actionableList = []
 
-    def mockDefaults(pipelineScript) {
-    }
-
     def mock(pipelineScript) {
         actionableList.each { emulatingToken -> mockFromMap(pipelineScript, emulatingToken) }
     }

--- a/src/main/groovy/com/passfailerror/syntax/Steps.groovy
+++ b/src/main/groovy/com/passfailerror/syntax/Steps.groovy
@@ -17,10 +17,6 @@ class Steps implements Token {
     def actionableList = []
 
     def mockDefaults(pipelineScript) {
-        pipelineScript.metaClass.methodMissing = { String currentStepName, params ->
-            log.info(currentStepName + " " + params[0].toString())
-            resultStackProcessor.storeInvocation(currentStepName, params, pipelineScript.getBinding().getVariables())
-        }
     }
 
     def mock(pipelineScript) {

--- a/src/main/groovy/com/passfailerror/syntax/Steps.groovy
+++ b/src/main/groovy/com/passfailerror/syntax/Steps.groovy
@@ -40,13 +40,9 @@ class Steps implements Token {
     def actionableList = []
 
     def mockDefaults(pipelineScript) {
-        defaultSteps.each {
-            step ->
-                def currentStep = step
-                pipelineScript.metaClass."$currentStep" = { Object... params ->
-                    log.info(currentStep + " " + params[0].toString())
-                    resultStackProcessor.storeInvocation(currentStep, params, pipelineScript.getBinding().getVariables())
-                }
+        pipelineScript.metaClass.methodMissing = { String currentStepName, params ->
+            log.info(currentStepName + " " + params[0].toString())
+            resultStackProcessor.storeInvocation(currentStepName, params, pipelineScript.getBinding().getVariables())
         }
     }
 

--- a/src/main/groovy/com/passfailerror/syntax/Token.groovy
+++ b/src/main/groovy/com/passfailerror/syntax/Token.groovy
@@ -3,6 +3,4 @@ package com.passfailerror.syntax
 interface Token {
 
     def mock(pipelineScript)
-
-    def mockDefaults(pipelineScript)
 }


### PR DESCRIPTION
Groovy mechanism methodMissing is now used to provide default items mocking. This is for currently supported items: steps and sections. The mechanism is global one and is invoked in Jenkinson class.